### PR TITLE
Fix LHE `Observable` and `Cut` parsing

### DIFF
--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -475,8 +475,11 @@ def _parse_cuts(cuts, fail_cuts, observables, observations, pass_all_cuts, pass_
 
     # Check cuts
     for i_cut, cut in enumerate(cuts):
+        definition = cut.val_expression
+        required = cut.is_required
+
         try:
-            cut_result = eval(cut, variables)
+            cut_result = eval(definition, variables)
             if cut_result:
                 pass_cuts[i_cut] += 1
             else:
@@ -484,7 +487,7 @@ def _parse_cuts(cuts, fail_cuts, observables, observations, pass_all_cuts, pass_
                 pass_all_cuts = False
 
         except (SyntaxError, NameError, TypeError, ZeroDivisionError, IndexError):
-            if cut.is_required:
+            if required:
                 pass_cuts[i_cut] += 1
             else:
                 fail_cuts[i_cut] += 1


### PR DESCRIPTION
This PR addresses issue https://github.com/madminer-tool/madminer/issues/492, where two bugs were introduced when adapting the code to the new `Observable` and `Cut` data classes. The fix leaves the [_parse_observations](https://github.com/madminer-tool/madminer/blob/v0.9.0/madminer/utils/interfaces/lhe.py#L403-L430) and [_parse_cuts](https://github.com/madminer-tool/madminer/blob/v0.9.0/madminer/utils/interfaces/lhe.py#L470-L492) functions with the same logic as in version `0.8.3`.

This fix will be applied to the version `0.9.1`, once it is released.