### PR TITLE
Fix Fisher information covariance calc.

### DIFF
--- a/madminer/fisherinformation/information.py
+++ b/madminer/fisherinformation/information.py
@@ -371,10 +371,10 @@ class FisherInformation(DataAnalyzer):
                     covariance = None
 
         # Returns
-        if model_is_ensemble:
+        if model_is_ensemble and calculate_covariance:
             return fisher_info_rate + fisher_info_kin, rate_covariance + covariance
-
-        return fisher_info_rate + fisher_info_kin, rate_covariance
+        else:
+            return fisher_info_rate + fisher_info_kin, rate_covariance
 
     def rate_information(
         self,


### PR DESCRIPTION
This PR fixes issue https://github.com/madminer-tool/madminer/issues/495 by modifying the return logic of the [`FisherInformation.full_information`](https://github.com/madminer-tool/madminer/blob/v0.9.1/madminer/fisherinformation/information.py#L137-L148) function in order to avoid the summation of an empty valued covariance when the `calculate_covariance` parameter is False.

In addition, it improves the function code format.

--

cc @konda111