### PR TITLE
Remove legacy XML imports

### DIFF
--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -92,23 +92,25 @@ def parse_lhe_file(
             weight_norm_is_average = value == "average"
 
             logger.debug(
-                "Found entry event_norm = %s in LHE header. Interpreting this as weight_norm_is_average " "= %s.",
+                "Found entry event_norm = %s in LHE header. "
+                "Interpreting this as weight_norm_is_average = %s.",
                 value,
                 weight_norm_is_average,
             )
 
     if weight_norm_is_average is None:
         logger.warning(
-            "Cannot read weight normalization mode (entry 'event_norm') from LHE file header. MadMiner "
-            "will continue assuming that events are properly normalized. Please check this!"
+            "Cannot read weight normalization mode (entry 'event_norm') from LHE file header. "
+            "MadMiner will continue assuming that events are properly normalized. "
+            "Please check this!"
         )
 
     # If necessary, rescale by number of events
     if weight_norm_is_average:
         if n_events_runcard is None:
             raise RuntimeError(
-                "LHE weights have to be normalized, but MadMiner cannot read number of events (entry "
-                "'nevents') from LHE file header."
+                "LHE weights have to be normalized, "
+                "but MadMiner cannot read number of events (entry 'nevents') from LHE file header."
             )
 
         k_factor = k_factor / n_events_runcard
@@ -633,7 +635,7 @@ def _extract_nuisance_param_dict(weight_groups: list, systematics_name: str, sys
             try:
                 wg_name = wg.attrib["name"]
             except KeyError:
-                logger.warning("New wWeight group: does not have name attribute, skipping")
+                logger.warning("New weight group: does not have name attribute, skipping")
                 continue
             logger.debug("New weight group: %s", wg_name)
 


### PR DESCRIPTION
This PR removes the legacy `xml.etree.cElementTree` import from the beginning of the [utils/interfaces/lhe.py](https://github.com/madminer-tool/madminer/blob/v0.9.1/madminer/utils/interfaces/lhe.py#L10-L15) module. According to [the official documentation](https://docs.python.org/3.7/library/xml.etree.elementtree.html), the standard library module _will use the fast implementation automatically whenever available_.

In addition, some logging messages have improved format.