### PR TITLE
Add MWST sets to the accepted nuisance params.

### DIFF
--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -641,6 +641,7 @@ def _extract_nuisance_param_dict(weight_groups: list, systematics_name: str, sys
 
             if (
                 "mg_reweighting" in wg_name.lower()
+                or "mwst" not in wg_name.lower()
                 or "pdf" not in wg_name.lower()
                 or "ct" not in wg_name.lower()
                 or systematic.value not in wg_name.lower()


### PR DESCRIPTION
This PR addresses issue https://github.com/madminer-tool/madminer/issues/494 by providing a _partial_ solution to the identification of [all PDF sets](https://lhapdf.hepforge.org/pdfsets.html) in the _nuisance parameters_ LHE file reading function.

--

cc @konda111