### PR TITLE
style: apply black 22.1 formatting to notebooks

### DIFF
--- a/examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb
+++ b/examples/tutorial_toy_simulator/tutorial_toy_simulator.ipynb
@@ -135,7 +135,7 @@
     "        r_xz = None\n",
     "\n",
     "    if theta_score is not None:\n",
-    "        t_xz = (x - theta_score) / z_std ** 2\n",
+    "        t_xz = (x - theta_score) / z_std**2\n",
     "    else:\n",
     "        t_xz = None\n",
     "\n",
@@ -156,7 +156,7 @@
    "outputs": [],
    "source": [
     "def calculate_likelihood_ratio(x, theta0, theta1=0.0):\n",
-    "    combined_std = (z_std ** 2 + x_std ** 2) ** 0.5\n",
+    "    combined_std = (z_std**2 + x_std**2) ** 0.5\n",
     "    r_x = norm(loc=theta0, scale=combined_std).pdf(x) / norm(loc=theta1, scale=combined_std).pdf(x)\n",
     "    return r_x"
    ]


### PR DESCRIPTION
The [first non-beta release of `black`, `22.1.0`](https://black.readthedocs.io/en/stable/change_log.html) introduced some small formatting changes, most notably the removal of spaces around powers `**`. This updates the code to the latest version of `black`.

#480 introduced the `black` formatting for the example notebooks, and the CI currently fails due to the changes to `black`, as it checks for formatting changes:
https://github.com/madminer-tool/madminer/blob/6556f164725baab6b79e5ffa2a64913a0ac50f7a/.github/workflows/ci.yml#L39 

This PR will fix that part of the CI.

This PR does not touch the main library itself, and running `black` over that would currently touch 47 files. That is a bigger change that may be worth considering separately.