### PR TITLE
Improve and simplify Python syntax

### DIFF
--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -85,8 +85,8 @@ class DelphesReader:
         self.events_sampling_benchmark_ids = []
 
         # Initialize event summary
-        self.signal_events_per_benchmark = None
-        self.background_events = None
+        self.signal_events_per_benchmark = []
+        self.background_events = 0
 
         # Information from .h5 file
         self.filename = filename

--- a/madminer/fisherinformation/geometry.py
+++ b/madminer/fisherinformation/geometry.py
@@ -351,6 +351,7 @@ class InformationGeometry:
         # determine trajectories
         thetas = []
         distances = []
+
         for i in range(ntrajectories):
             if continous_sampling:
                 angle = 2.0 * np.pi / float(ntrajectories) * i
@@ -360,10 +361,10 @@ class InformationGeometry:
 
             logger.debug(f"Calculate Trajectory Number {i} with dtheta0={dth0}")
             ths, ds = self.find_trajectory(theta0, dth0, limits, stepsize)
-            for th in ths:
-                thetas.append(th)
-            for d in ds:
-                distances.append(d)
+
+            thetas.extend(ths)
+            distances.extend(ds)
+
         thetas = np.array(thetas)
 
         # Create Theta Grid

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -90,8 +90,8 @@ class LHEReader:
         self.events_sampling_benchmark_ids = []
 
         # Initialize event summary
-        self.signal_events_per_benchmark = None
-        self.background_events = None
+        self.signal_events_per_benchmark = []
+        self.background_events = 0
 
         # Information from .h5 file
         self.filename = filename

--- a/madminer/likelihood/histo.py
+++ b/madminer/likelihood/histo.py
@@ -585,9 +585,7 @@ class HistoLikelihood(BaseLikelihood):
         """
 
         # get array of flattened histograms
-        flattened_histo_weights = []
-        for histo in histogram_benchmarks:
-            flattened_histo_weights.append(histo.flatten())
+        flattened_histo_weights = [histo.flatten() for histo in histogram_benchmarks]
         flattened_histo_weights = np.array(flattened_histo_weights).T
 
         # calculate dot product
@@ -595,5 +593,4 @@ class HistoLikelihood(BaseLikelihood):
         histo_weights_theta = mdot(theta_matrix, flattened_histo_weights)
 
         # create histogram
-        histo = Histo(bin_centers, weights=histo_weights_theta, bins=hist_bins, epsilon=1.0e-12)
-        return histo
+        return Histo(bin_centers, weights=histo_weights_theta, bins=hist_bins, epsilon=1.0e-12)

--- a/madminer/models/benchmarks.py
+++ b/madminer/models/benchmarks.py
@@ -31,10 +31,7 @@ class Benchmark:
 
         return cls(
             name=name,
-            values=OrderedDict(
-                (p_name, p_value)
-                for p_name, p_value in zip(param_names, param_values)
-            ),
+            values=OrderedDict(zip(param_names, param_values)),
         )
 
     def __str__(self) -> str:
@@ -105,8 +102,5 @@ class FiniteDiffBenchmark:
 
         return cls(
             base_name=base_name,
-            shift_names=OrderedDict(
-                (p_name, shift_name)
-                for p_name, shift_name in zip(param_names, shift_names)
-            ),
+            shift_names=OrderedDict(zip(param_names, shift_names)),
         )

--- a/madminer/utils/histo.py
+++ b/madminer/utils/histo.py
@@ -86,17 +86,19 @@ class Histo:
             bins_in = [bins_in for _ in range(self.n_observables)]
 
         # Find binning along each observable direction
-        n_bins = []
+        num_bins = []
         bin_edges = []
 
         for this_bins, this_x in zip(bins_in, x.T):
             if isinstance(this_bins, int):
-                bin_edges.append(self._adaptive_binning(this_x, this_bins, weights=weights))
+                edges = self._adaptive_binning(this_x, this_bins, weights=weights)
             else:
-                bin_edges.append(this_bins)
-            n_bins.append(len(bin_edges[-1]) - 1)
+                edges = this_bins
 
-        return n_bins, bin_edges
+            num_bins.append(len(edges) - 1)
+            bin_edges.append(edges)
+
+        return num_bins, bin_edges
 
     @staticmethod
     def _adaptive_binning(x, n_bins, weights=None, lower_cutoff_percentile=0.1, upper_cutoff_percentile=99.9):

--- a/madminer/utils/interfaces/hdf5.py
+++ b/madminer/utils/interfaces/hdf5.py
@@ -394,8 +394,8 @@ def save_events(
     observations: dict,
     weights: dict,
     sampling_benchmarks: List[int],
-    num_signal_events: List[int] = None,
-    num_background_events: int = None,
+    num_signal_events: List[int],
+    num_background_events: int,
 ) -> None:
     """
     Saves generated events information into a HDF5 data file
@@ -1174,12 +1174,6 @@ def _save_samples_summary(
     -------
         None
     """
-
-    if num_signal_events is None:
-        num_signal_events = []
-
-    if num_background_events is None:
-        num_background_events = 0
 
     # Append if file exists, otherwise create
     with h5py.File(file_name, "a") as file:

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -48,9 +48,9 @@ def parse_lhe_file(
 
     # Inputs
     if cuts is None:
-        cuts = OrderedDict()
+        cuts = []
     if efficiencies is None:
-        efficiencies = OrderedDict()
+        efficiencies = []
     if k_factor is None:
         k_factor = 1.0
     if is_background and benchmark_names is None:


### PR DESCRIPTION
This PR contains a series of readability and syntax improvements since the last release.

Listed:
- Replace short for-loops by list comprehensions and extend calls.
- Simplify how the [Benchmark](https://github.com/madminer-tool/madminer/blob/0df492859a3c4b0208cb6a0127761fec22e51588/madminer/models/benchmarks.py#L9-L78) model have its `values` dictionary built.
- Simplify how the [FiniteDiffBenchmark](https://github.com/madminer-tool/madminer/blob/0df492859a3c4b0208cb6a0127761fec22e51588/madminer/models/benchmarks.py#L82-L106) model have its `shift_names` dictionary built.
- Improve readability on `histo.py` [_calculate_binning](https://github.com/madminer-tool/madminer/blob/0df492859a3c4b0208cb6a0127761fec22e51588/madminer/utils/histo.py#L84-L101) function.
- Removes the default values of the `hdf5.py` [save_events](https://github.com/madminer-tool/madminer/blob/0df492859a3c4b0208cb6a0127761fec22e51588/madminer/utils/interfaces/hdf5.py#L390-L440) public function.