### PR TITLE
ci: Add workflow_dispatch and concurrency to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ on:
     paths-ignore:
       - "**.md"
       - "**.rst"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,11 @@ on:
       - "docs/**"
       - "madminer/**"
       - "setup.py"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
Add `workflow_dispatch` triggers to be able to run workflows on demand, and add concurrency to automatically cancel workflows that have been superseded.