### PR TITLE
build: Remove upper bound on python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7, <4.0
+python_requires = >=3.7
 install_requires =
     h5py
     matplotlib>=2.0.0


### PR DESCRIPTION
Remove upper bound on python_requires to avoid artificially making madminer impossible to install with future releases of Python.
   - c.f. https://iscinumpy.dev/post/bound-version-constraints/