### PR TITLE
feat: switch from uproot3 to uproot

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,5 @@ dependencies:
 - pip
 - pip:
   - particle>=0.16.0
-  - uproot3>=3.14.1
+  - uproot>=4.0.0
   - vector>=0.8.4

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 import os
-import uproot3
+import uproot
 
 from collections import OrderedDict
 from typing import Callable
@@ -43,7 +43,7 @@ def parse_delphes_root_file(
         logger.debug("Extracting weights %s", weight_labels)
 
     # Delphes ROOT file
-    root_file = uproot3.open(delphes_sample_file)
+    root_file = uproot.open(delphes_sample_file)
 
     # Delphes tree
     tree = root_file["Delphes"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     particle>=0.16.0
     scipy>=1.0.0
     torch>=1.0.0
-    uproot3>=3.14.1
+    uproot>=4.0.0
     vector>=0.8.4
 
 [options.packages.find]


### PR DESCRIPTION
[`uproot3`](https://github.com/scikit-hep/uproot3) is deprecated and has been superseded by the library now called [`uproot`](https://github.com/scikit-hep/uproot5). As noted in #455, some API changes imply that the Delphes interface needs a bit of refactoring (not done yet).

to-do:
- actually refactor Delphes interface and confirm that everything still runs