### PR TITLE
docs: set language to fix warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
The current `language = None` setting results in a Sphinx warning, which in CI is treated as an error, so CI fails:
```
Running Sphinx v5.1.1
Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
make: *** [Makefile:1[9](https://github.com/madminer-tool/madminer/runs/8015958086?check_suite_focus=true#step:5:10): html] Error 2
Error: Process completed with exit code 2.
```
taken from https://github.com/madminer-tool/madminer/runs/8015958086.