### PR TITLE
Restrict Fisher information calc. based on nuisance_morpher

### DIFF
--- a/madminer/fisherinformation/information.py
+++ b/madminer/fisherinformation/information.py
@@ -1216,7 +1216,6 @@ class FisherInformation(DataAnalyzer):
 
         # Get differential xsec per event, and the derivative wrt to theta
         sigma = mdot(theta_matrix, weights_benchmarks)  # Shape (n_events,)
-        total_xsec = np.sum(sigma)
         inv_sigma = sanitize_array(1.0 / sigma)  # Shape (n_events,)
         dsigma = mdot(dtheta_matrix, weights_benchmarks)  # Shape (n_parameters, n_events)
 

--- a/madminer/fisherinformation/information.py
+++ b/madminer/fisherinformation/information.py
@@ -1208,10 +1208,7 @@ class FisherInformation(DataAnalyzer):
             does not take into account any uncertainty on the nuisance parameter part of the Fisher information, and
             correlations between events are neglected. Note that independent of sum_events, the covariance matrix is
             always summed over the events.
-
         """
-
-        include_nuisance_parameters = include_nuisance_parameters and self.include_nuisance_parameters
 
         # Get morphing matrices
         theta_matrix = self._get_theta_benchmark_matrix(theta, zero_pad=False)  # (n_benchmarks_phys,)
@@ -1226,8 +1223,11 @@ class FisherInformation(DataAnalyzer):
         # Calculate physics Fisher info for this event
         fisher_info_phys = luminosity * np.einsum("n,in,jn->nij", inv_sigma, dsigma, dsigma)
 
+        if include_nuisance_parameters and self.nuisance_morpher is None:
+            logger.warning("Cannot include nuisance parameters as none were found in the setup file")
+
         # Nuisance parameter Fisher info
-        if include_nuisance_parameters:
+        if include_nuisance_parameters and self.nuisance_morpher is not None:
             nuisance_a = self.nuisance_morpher.calculate_a(weights_benchmarks)  # Shape (n_nuisance_params, n_events)
             # grad_i dsigma(x), where i is a nuisance parameter, is given by
             # sigma[np.newaxis, :] * a

--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -1734,7 +1734,7 @@ class SampleAugmenter(DataAnalyzer):
                 add_nuisance_params = True
 
         # No nuisance params?
-        if not add_nuisance_params or self.nuisance_morpher is None or self.n_nuisance_parameters == 0:
+        if not add_nuisance_params or self.nuisance_morpher is None:
             return all_thetas
 
         all_combined = []


### PR DESCRIPTION
This PR **partially** addresses issue https://github.com/madminer-tool/madminer/issues/517 by restricting the calculation of fisher information when `nuisance_morpher` is `None`.

I find this approach better than restoring DataAnalyzer safe-guard overriding user input for `include_nuisance_parameters` ([reference](https://github.com/madminer-tool/madminer/blob/v0.8.3/madminer/analysis/dataanalyzer.py#L71-L77)) for a couple of reasons:
- It is better for traceability purposes.
- It harmonised all nuisance params existance checks, as the `self.nuisance_morpher is not None` snippet is found in many other places within the codebase.

### Additional changes
- Removed unused local variable within the fisher calculation method (https://github.com/madminer-tool/madminer/commit/1d8210a4cacea9795828840e57e69174dc3d77e5).
- Removed redudant nuisance params check within the `SampleAugmenter` class (https://github.com/madminer-tool/madminer/commit/3e3ffe0806a9bc006b2768d56a444912fafefd5a).