### PR TITLE
Fix morphing_example notebook typos

### DIFF
--- a/examples/morphing_basis/morphing_example.ipynb
+++ b/examples/morphing_basis/morphing_example.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Morphing is a functionality implemented by madminer that allows for the fast and exact interpolation of event weights (or any derived quantity) from a set of original benchmark points (the “morphing basis”) to anywhere in theory parameter space. In this jupyter notebook, we will be focus on how to utilizing the morphing function of madminer."
+    "Morphing is a functionality implemented by madminer that allows for the fast and exact interpolation of event weights (or any derived quantity) from a set of original benchmark points (the “morphing basis”) to anywhere in theory parameter space. In this jupyter notebook, we will be focusing on how to use the morphing function of madminer."
    ]
   },
   {
@@ -102,7 +102,7 @@
     "morpher_1.set_basis(basis_numpy=basis_numpy)\n",
     "print(\"basis:\\n\", morpher_1.basis)\n",
     "\n",
-    "# To this step, the prepartion works are done."
+    "# To this step, the preparation works are done."
    ]
   },
   {
@@ -156,8 +156,8 @@
     "\n",
     "# in the parameter input we had input basis points such from (1,-5) to (1,-1).\n",
     "# if we want to predict the point theta = [1,1], and the known xsec is listed below\n",
-    "# The coressponding xsec for the above basis points are xsec_simulated[0:5]\n",
-    "# we are predicting the value of xsec_simulatd[6]\n",
+    "# The corresponding xsec for the above basis points are xsec_simulated[0:5]\n",
+    "# we are predicting the value of xsec_simulated[6]\n",
     "xsec_simulated = np.array([0.759, 0.53, 0.4, 0.335, 0.316, 0.316, 0.328, 0.34, 0.354, 0.364])\n",
     "morphing_1_weights = morpher_1.calculate_morphing_weights(theta=[1, 1])\n",
     "print(\"Morphing matrix weights: \\n\", morphing_1_weights)\n",
@@ -167,16 +167,16 @@
     "print(\"simulated value: \\n\", xsec_simulated[6])\n",
     "print(\"\\n\")\n",
     "\n",
-    "# We can see and compare the predict value with the simulated values."
+    "# We can see and compare the predicted value with the simulated values."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Second Input Fromat\n",
+    "## 2. Second Input Format\n",
     "\n",
-    "The second input format allows you to specify basis from different couplings separately, which allows user to specify couplings groups of production (gp), decay(gd) and same (gs, work as both production and decay) separately, each with a shape of (n_parameters, n_basis_points). In addition, the second input format supports overdetermined morphing, which allows you to input more basis points than minimun requirement for better accruacy. "
+    "The second input format allows you to specify basis from different couplings separately, which allows user to specify couplings groups of production (gp), decay(gd) and same (gs, work as both production and decay) separately, each with a shape of (n_parameters, n_basis_points). In addition, the second input format supports overdetermined morphing, which allows you to input more basis points than minimun requirement for better accuracy. "
    ]
   },
   {
@@ -191,19 +191,24 @@
     "# First, we should create a new morpher object using the code below\n",
     "morpher_2 = m.PhysicsMorpher(parameter_max_power=[2, 2])\n",
     "\n",
-    "# We set the componet value the same as previous\n",
+    "# We set the component value the same as previous\n",
     "this_components = np.array([[4, 0], [3, 1], [2, 2], [1, 3], [0, 4]])\n",
     "morpher_2.set_components(this_components)\n",
     "\n",
     "# gs means the couplings that work for both production and decay.\n",
-    "# Please note that the input format of the each coupling group is the transpose of the previous format\n",
+    "# Please note that the input format of each coupling group is the transpose of the previous format\n",
     "# In this case, the gs will have six basis points instead of the previous 5\n",
-    "gs = np.array([[1, 1, 1, 1, 1, 1], [-5, -4, -3, -2, -1, 0]])\n",
+    "gs = np.array(\n",
+    "    [\n",
+    "        [+1, +1, +1, +1, +1, 1],\n",
+    "        [-5, -4, -3, -2, -1, 0],\n",
+    "    ]\n",
+    ")\n",
     "\n",
     "# We set the basis value of the morpher\n",
     "morpher_2.set_basis(basis_d=None, basis_p=None, basis_s=gs)\n",
     "\n",
-    "# To this step, the prepartion works are done."
+    "# To this step, the preparation works are done."
    ]
   },
   {
@@ -222,14 +227,14 @@
     }
    ],
    "source": [
-    "# The other functions are the is the same as the previous example\n",
+    "# The other functions are the same as the previous example\n",
     "# We can get the morphing functions, weights, and xsec values\n",
     "morpher_2_matrix = morpher_2.calculate_morphing_matrix()\n",
     "\n",
     "# We input the same theta value as the previous example\n",
     "morpher_2_weight = morpher_2.calculate_morphing_weights(theta=[1, 1])\n",
     "\n",
-    "# calculate the predict value of point [1,1] with six basis points\n",
+    "# calculate the predicted value of point [1,1] with six basis points\n",
     "n_base_6 = calculate_predict_xsec(morphing_weights=morpher_2_weight, xsec=xsec_simulated)\n",
     "\n",
     "# We compare the results of the regular and overdetermined morphing with simulated value\n",
@@ -238,7 +243,7 @@
     "print(\"regular predict value\", n_base_5)\n",
     "print(\"overdetermined predict value:\", n_base_6)\n",
     "\n",
-    "# We can see with only one additional basis point, the predict value is much more close to the simulated value"
+    "# We can see with only one additional basis point, the predicted value is much more close to the simulated value"
    ]
   },
   {
@@ -278,8 +283,8 @@
    "source": [
     "## 3. Specifying different coupling groups independently. \n",
     "\n",
-    "We mentioned that the second format allows user to specify different coupling groups separately, which allow user to do morphing with more specified basis points selectoins.\n",
-    "Below is an example using this functinality. "
+    "We mentioned that the second format allows user to specify different coupling groups separately, which allow user to do morphing with more specified basis points selections.\n",
+    "Below is an example using this functionality. "
    ]
   },
   {
@@ -363,7 +368,7 @@
     "morpher_3.set_basis(basis_d=gd, basis_p=gp, basis_s=gs)\n",
     "print(\"Morphing_matrix:\\n\", morpher_3.calculate_morphing_matrix())\n",
     "\n",
-    "# The prepartion steps are done"
+    "# The preparation steps are done"
    ]
   },
   {
@@ -392,7 +397,7 @@
     "    xsec=simulate_xsec, morphing_weights=morpher_3_weights\n",
     ")\n",
     "\n",
-    "# The expected xsec value is the the last one in simulated_xsec, which is the 13th input we have\n",
+    "# The expected xsec value is the last one in simulated_xsec, which is the 13th input we have\n",
     "expected_xsec_value = simulate_xsec[-1]\n",
     "\n",
     "print(\"Predict xsec value: \", morpher_3_predicted_xsec)\n",
@@ -403,7 +408,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that we are able to predict the xsec value that is very close to the actual simulated xsec values. Remember, we only used the first the six xsec values and points to predict the 13th xsec value. As mentioned earlier, we supports overdetermined morphing and can always input more known basis points and corresponding xsec values to get better results. "
+    "We can see that we are able to predict the xsec value that is very close to the actual simulated xsec values. Remember, we only used the first the six xsec values and points to predict the 13th xsec value. As mentioned earlier, we support overdetermined morphing and can always input more known basis points and corresponding xsec values to get better results. "
    ]
   }
  ],

--- a/examples/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/examples/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -208,18 +208,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "u\"\\nminer.run(\\n    is_background=True,\\n    sample_benchmark='sm',\\n    mg_directory=mg_dir,\\n    mg_process_directory='./mg_processes/background_pythia',\\n    proc_card_file='cards/proc_card_background.dat',\\n    pythia8_card_file='cards/pythia8_card.dat',\\n    param_card_template_file='cards/param_card_template.dat',\\n    run_card_file='cards/run_card_background.dat',\\n    log_directory='logs/background',\\n)\\n\""
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"\n",
     "miner.run(\n",
@@ -296,16 +285,6 @@
      "text": [
       "16:35 madminer.delphes     DEBUG   Adding event sample mg_processes/signal_pythia/Events/run_01/tag_1_pythia8_events.hepmc.gz\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "u\"\\ndelphes.add_sample(\\n    lhe_filename='mg_processes/background_pythia/Events/run_01/unweighted_events.lhe.gz',\\n    hepmc_filename='mg_processes/background_pythia/Events/run_01/tag_1_pythia8_events.hepmc.gz',\\n    sampled_from_benchmark='sm',\\n    is_background=True,\\n    k_factor=1.0,\\n\""
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [


### PR DESCRIPTION
This PR fixes typos throughout the [morphing_example.ipynb](https://github.com/madminer-tool/madminer/blob/master/examples/morphing_basis/morphing_example.ipynb) notebook.

This notebooks was merged as part of the _adding overdetermined morphing_ effort in [this PR](https://github.com/madminer-tool/madminer/pull/506).
