### PR TITLE
Refactor DataAnalyzer train / test / validation split calc.

### DIFF
--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -306,7 +306,7 @@ class DataAnalyzer:
             start_event, end_event = None, None
             correction_factor = 1.0
         elif partition in ["train", "validation", "test"]:
-            start_event, end_event, correction_factor = self._train_validation_test_split(
+            start_event, end_event, correction_factor = self._calculate_partition_bounds(
                 partition, test_split, validation_split
             )
         else:
@@ -440,7 +440,7 @@ class DataAnalyzer:
             start_event, end_event = None, None
             correction_factor = 1.0
         elif partition in ["train", "validation", "test"]:
-            start_event, end_event, correction_factor = self._train_validation_test_split(
+            start_event, end_event, correction_factor = self._calculate_partition_bounds(
                 partition, test_split, validation_split
             )
         else:
@@ -735,51 +735,7 @@ class DataAnalyzer:
             return dweight_dnu
         return np.concatenate((dweight_dtheta, dweight_dnu), 1)
 
-    def _train_test_split(self, train, test_split):
-        """
-        Returns the start and end event for train samples (train = True) or test samples (train = False).
-
-        Parameters
-        ----------
-        train : bool
-            True if training data is generated, False if test data is generated.
-
-        test_split : float
-            Fraction of events reserved for testing.
-
-        Returns
-        -------
-        start_event : int
-            Index (in the MadMiner file) of the first event to consider.
-
-        end_event : int
-            Index (in the MadMiner file) of the last unweighted event to consider.
-
-        correction_factor : float
-            Factor with which the weights and cross sections will have to be multiplied to make up for the missing
-            events.
-        """
-
-        train_split = 1.0 - test_split
-
-        if not all((
-            self._is_split_valid(test_split),
-            self._is_split_valid(train_split),
-        )):
-            return 0, None, 1.0
-
-        if train:
-            start_event = 0
-            end_event = self._calculate_end_event(train_split)
-            correction_factor = 1.0 / train_split
-        else:
-            start_event = self._calculate_start_event(train_split)
-            end_event = None
-            correction_factor = 1.0 / test_split
-
-        return start_event, end_event, correction_factor
-
-    def _train_validation_test_split(self, partition, test_split, validation_split):
+    def _calculate_partition_bounds(self, partition: str, test_split: float, validation_split: float = 0.0):
         """
         Returns the start and end event for samples of the desired partition ("train", "test" or "validation")
         given test and validation splits.
@@ -791,7 +747,7 @@ class DataAnalyzer:
         test_split : float
             Fraction of events reserved for testing.
 
-        validation_split : float
+        validation_split : float, optional
             Fraction of events reserved for testing.
 
         Returns

--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -760,6 +760,8 @@ class DataAnalyzer:
             events.
         """
 
+        train_split = 1.0 - test_split
+
         if train:
             start_event = 0
 
@@ -767,8 +769,8 @@ class DataAnalyzer:
                 end_event = None
                 correction_factor = 1.0
             else:
-                end_event = int(round((1.0 - test_split) * self.n_samples, 0))
-                correction_factor = 1.0 / (1.0 - test_split)
+                end_event = int(round(train_split * self.n_samples, 0))
+                correction_factor = 1.0 / train_split
                 if end_event < 0 or end_event > self.n_samples:
                     raise ValueError(f"Irregular split: sample {end_event} / {self.n_samples}")
 
@@ -777,7 +779,7 @@ class DataAnalyzer:
                 start_event = 0
                 correction_factor = 1.0
             else:
-                start_event = int(round((1.0 - test_split) * self.n_samples, 0)) + 1
+                start_event = int(round(train_split * self.n_samples, 0)) + 1
                 correction_factor = 1.0 / test_split
                 if start_event < 0 or start_event > self.n_samples:
                     raise ValueError(f"Irregular split: sample {start_event} / {self.n_samples}")

--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -596,6 +596,12 @@ class DataAnalyzer:
         return matrix
 
     @staticmethod
+    def _is_split_valid(split: float) -> bool:
+        """Validates whether a train / test / validation split is a valid number"""
+
+        return split is not None and 0.0 <= split <= 1.0
+
+    @staticmethod
     def _any_nontrivial_nus(nus):
         if nus is None:
             return False
@@ -752,12 +758,12 @@ class DataAnalyzer:
         correction_factor : float
             Factor with which the weights and cross sections will have to be multiplied to make up for the missing
             events.
-
         """
+
         if train:
             start_event = 0
 
-            if test_split is None or test_split <= 0.0 or test_split >= 1.0:
+            if not self._is_split_valid(test_split):
                 end_event = None
                 correction_factor = 1.0
             else:
@@ -767,7 +773,7 @@ class DataAnalyzer:
                     raise ValueError(f"Irregular split: sample {end_event} / {self.n_samples}")
 
         else:
-            if test_split is None or test_split <= 0.0 or test_split >= 1.0:
+            if not self._is_split_valid(test_split):
                 start_event = 0
                 correction_factor = 1.0
             else:
@@ -805,19 +811,20 @@ class DataAnalyzer:
         correction_factor : float
             Factor with which the weights and cross sections will have to be multiplied to make up for the missing
             events.
-
         """
+
         if test_split is None or test_split < 0.0:
             test_split = 0.0
         if validation_split is None or validation_split < 0.0:
             validation_split = 0.0
+
         assert test_split + validation_split <= 1.0
         train_split = 1.0 - test_split - validation_split
 
         if partition == "train":
             start_event = 0
 
-            if test_split is None or test_split <= 0.0 or test_split >= 1.0:
+            if not self._is_split_valid(test_split):
                 end_event = None
                 correction_factor = 1.0
             else:
@@ -828,11 +835,10 @@ class DataAnalyzer:
                     raise ValueError(f"Irregular split: sample {end_event} / {self.n_samples}")
 
         elif partition == "validation":
-            if validation_split is None or validation_split <= 0.0 or validation_split >= 1.0:
+            if not self._is_split_valid(validation_split):
                 start_event = 0
                 end_event = None
                 correction_factor = 1.0
-
             else:
                 start_event = int(round(train_split * self.n_samples, 0)) + 1
                 end_event = int(round((1.0 - test_split) * self.n_samples, 0))
@@ -840,14 +846,13 @@ class DataAnalyzer:
 
                 if start_event < 0 or start_event > self.n_samples:
                     raise ValueError(f"Irregular split: sample {start_event} / {self.n_samples}")
-
                 if end_event < 0 or end_event > self.n_samples:
                     raise ValueError(f"Irregular split: sample {end_event} / {self.n_samples}")
 
         elif partition == "test":
             end_event = None
 
-            if test_split is None or test_split <= 0.0 or test_split >= 1.0:
+            if not self._is_split_valid(test_split):
                 start_event = 0
                 correction_factor = 1.0
             else:

--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -767,20 +767,11 @@ class DataAnalyzer:
         if train:
             start_event = 0
             end_event = self._calculate_end_event(test_split, train_split)
-
-            if not self._is_split_valid(test_split):
-                correction_factor = 1.0
-            else:
-                correction_factor = 1.0 / train_split
+            correction_factor = self._calculate_correction_factor(train_split)
         else:
             start_event = self._calculate_start_event(test_split, train_split)
-
-            if not self._is_split_valid(test_split):
-                correction_factor = 1.0
-            else:
-                correction_factor = 1.0 / test_split
-
             end_event = None
+            correction_factor = self._calculate_correction_factor(test_split)
 
         return start_event, end_event, correction_factor
 
@@ -822,29 +813,17 @@ class DataAnalyzer:
         if partition == "train":
             start_event = 0
             end_event = self._calculate_end_event(test_split, train_split)
-
-            if not self._is_split_valid(test_split):
-                correction_factor = 1.0
-            else:
-                correction_factor = 1.0 / train_split
+            correction_factor = self._calculate_correction_factor(train_split)
 
         elif partition == "validation":
             start_event = self._calculate_start_event(test_split, train_split)
             end_event = self._calculate_end_event(test_split, 1.0 - test_split)
-
-            if not self._is_split_valid(validation_split):
-                correction_factor = 1.0
-            else:
-                correction_factor = 1.0 / validation_split
+            correction_factor = self._calculate_correction_factor(validation_split)
 
         elif partition == "test":
             start_event = self._calculate_start_event(test_split, 1.0 - test_split)
             end_event = None
-
-            if not self._is_split_valid(test_split):
-                correction_factor = 1.0
-            else:
-                correction_factor = 1.0 / test_split
+            correction_factor = self._calculate_correction_factor(test_split)
 
         else:
             raise RuntimeError(f"Unknown partition {partition}")
@@ -958,6 +937,16 @@ class DataAnalyzer:
                 raise ValueError(f"Irregular split: sample {end_event} / {self.n_samples}")
 
         return end_event
+
+    def _calculate_correction_factor(self, split: float) -> float:
+        """Calculates the correction factor of a particular split"""
+
+        if not self._is_split_valid(split):
+            correction_factor = 1.0
+        else:
+            correction_factor = 1.0 / split
+
+        return correction_factor
 
     def _find_closest_benchmark(self, theta):
         if theta is None:

--- a/madminer/likelihood/base.py
+++ b/madminer/likelihood/base.py
@@ -37,7 +37,7 @@ class BaseLikelihood(DataAnalyzer):
     ):
 
         # get data
-        start_event, end_event, correction_factor = self._train_test_split(False, test_split)
+        start_event, end_event, correction_factor = self._calculate_partition_bounds("test", test_split)
         x, weights_benchmarks = next(
             self.event_loader(
                 start=start_event,

--- a/madminer/likelihood/histo.py
+++ b/madminer/likelihood/histo.py
@@ -500,7 +500,7 @@ class HistoLikelihood(BaseLikelihood):
         Low-level function that creates weighted histogram data
         """
         # Get weighted events
-        start_event, end_event, correction_factor = self._train_test_split(True, test_split)
+        start_event, end_event, correction_factor = self._calculate_partition_bound("train", test_split)
         x, weights_benchmarks = self.weighted_events(start_event=start_event, end_event=end_event, n_draws=n_toys)
         weights_benchmarks *= self.n_samples / n_toys
 

--- a/madminer/likelihood/neural.py
+++ b/madminer/likelihood/neural.py
@@ -184,7 +184,7 @@ class NeuralLikelihood(BaseLikelihood):
         Low-level function that creates weighted events and returns weights
         """
 
-        start_event, end_event, correction_factor = self._train_test_split(True, test_split)
+        start_event, end_event, correction_factor = self._calculate_partition_bound("train", test_split)
         x, weights_benchmarks = self.weighted_events(start_event=start_event, end_event=end_event, n_draws=n_toys)
         weights_benchmarks *= self.n_samples / n_toys
 

--- a/madminer/limits/asymptotic_limits.py
+++ b/madminer/limits/asymptotic_limits.py
@@ -862,7 +862,7 @@ class AsymptoticLimits(DataAnalyzer):
 
     def _calculate_xsecs(self, thetas, test_split=0.2):
         # Test split
-        start_event, end_event, correction_factor = self._train_test_split(False, test_split)
+        start_event, end_event, correction_factor = self._calculate_partition_bound("test", test_split)
 
         # Total xsecs for benchmarks
         xsecs_benchmarks = 0.0
@@ -877,7 +877,7 @@ class AsymptoticLimits(DataAnalyzer):
         return np.asarray(xsecs)
 
     def _asimov_data(self, theta, test_split=0.2, sample_only_from_closest_benchmark=True, n_asimov=None):
-        start_event, end_event, correction_factor = self._train_test_split(False, test_split)
+        start_event, end_event, correction_factor = self._calculate_partition_bound("test", test_split)
         x, weights_benchmarks = next(
             self.event_loader(
                 start=start_event,
@@ -1019,7 +1019,7 @@ class AsymptoticLimits(DataAnalyzer):
 
     def _make_weighted_histo_data(self, summary_function, thetas, n_toys, test_split=0.2):
         # Get weighted events
-        start_event, end_event, _ = self._train_test_split(True, test_split)
+        start_event, end_event, _ = self._calculate_partition_bound("train", test_split)
         x, weights_benchmarks = self.weighted_events(start_event=start_event, end_event=end_event, n_draws=n_toys)
 
         # Calculate summary stats

--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -1575,7 +1575,7 @@ class SampleAugmenter(DataAnalyzer):
         largest_event_probability = 0.0
 
         # Main sampling loop
-        start_event, end_event, correction_factor = self._train_validation_test_split(
+        start_event, end_event, correction_factor = self._calculate_partition_bounds(
             partition, test_split, validation_split
         )
         logger.debug(


### PR DESCRIPTION
This PR refactors DataAnalyzer class methods to reuse same `start_event` and `end_event` calculation private methods.

This was possible by:
- Defining a [_calculate_start_event](https://github.com/madminer-tool/madminer/blob/03d8e6ae5fd07a983957c51d9ee601c252909c24/madminer/analysis/dataanalyzer.py#L921-L936) private method (duh).
- Defining a [_calculate_end_event](https://github.com/madminer-tool/madminer/blob/03d8e6ae5fd07a983957c51d9ee601c252909c24/madminer/analysis/dataanalyzer.py#L938-L953) private method (duh).
- Defining a [_is_valid_split](https://github.com/madminer-tool/madminer/blob/03d8e6ae5fd07a983957c51d9ee601c252909c24/madminer/analysis/dataanalyzer.py#L598-L602) private method.
- Doing all the _split validation_ checks once, at the beginning of the public methods.