### PR TITLE
Add sympy to conda dependency list

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - matplotlib>=2.0.0
 - numpy>=1.20.0
 - scipy>=1.0.0
+- sympy>=0.7.4
 - pytorch>=1.0.0
 - pytest
 - pip


### PR DESCRIPTION
This PR fixes a missing dependency within the conda `environmnt.yml` file, after merging PR https://github.com/madminer-tool/madminer/pull/506.