### PR TITLE
Lint package with isort 5.11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     - name: "Check format"
       run: |
         black --check madminer tests examples
+        isort --check madminer tests
 
   test:
     needs: [lint]

--- a/madminer/__init__.py
+++ b/madminer/__init__.py
@@ -1,51 +1,41 @@
 from .analysis import DataAnalyzer
 from .core import MadMiner
 from .delphes import DelphesReader
-from .fisherinformation import (
-    FisherInformation,
-    InformationGeometry,
-    profile_information,
-    project_information,
-)
+from .fisherinformation import FisherInformation
+from .fisherinformation import InformationGeometry
+from .fisherinformation import profile_information
+from .fisherinformation import project_information
 from .lhe import LHEReader
-from .likelihood import (
-    HistoLikelihood,
-    NeuralLikelihood,
-    fix_params,
-    project_log_likelihood,
-    profile_log_likelihood,
-)
+from .likelihood import HistoLikelihood
+from .likelihood import NeuralLikelihood
+from .likelihood import fix_params
+from .likelihood import project_log_likelihood
+from .likelihood import profile_log_likelihood
 from .limits import AsymptoticLimits
-from .ml import (
-    ParameterizedRatioEstimator,
-    DoubleParameterizedRatioEstimator,
-    LikelihoodEstimator,
-    ScoreEstimator,
-    MorphingAwareRatioEstimator,
-    Ensemble,
-    load_estimator,
-)
-from .plotting import (
-    plot_uncertainty,
-    plot_systematics,
-    plot_pvalue_limits,
-    plot_distribution_of_information,
-    plot_fisher_information_contours_2d,
-    plot_fisherinfo_barplot,
-    plot_nd_morphing_basis_slices,
-    plot_nd_morphing_basis_scatter,
-    plot_2d_morphing_basis,
-    plot_histograms,
-    plot_distributions,
-)
-from .sampling import (
-    SampleAugmenter,
-    combine_and_shuffle,
-    benchmark,
-    benchmarks,
-    morphing_point,
-    morphing_points,
-    random_morphing_points,
-    iid_nuisance_parameters,
-    nominal_nuisance_parameters,
-)
+from .ml import ParameterizedRatioEstimator
+from .ml import DoubleParameterizedRatioEstimator
+from .ml import LikelihoodEstimator
+from .ml import ScoreEstimator
+from .ml import MorphingAwareRatioEstimator
+from .ml import Ensemble
+from .ml import load_estimator
+from .plotting import plot_uncertainty
+from .plotting import plot_systematics
+from .plotting import plot_pvalue_limits
+from .plotting import plot_distribution_of_information
+from .plotting import plot_fisher_information_contours_2d
+from .plotting import plot_fisherinfo_barplot
+from .plotting import plot_nd_morphing_basis_slices
+from .plotting import plot_nd_morphing_basis_scatter
+from .plotting import plot_2d_morphing_basis
+from .plotting import plot_histograms
+from .plotting import plot_distributions
+from .sampling import SampleAugmenter
+from .sampling import combine_and_shuffle
+from .sampling import benchmark
+from .sampling import benchmarks
+from .sampling import morphing_point
+from .sampling import morphing_points
+from .sampling import random_morphing_points
+from .sampling import iid_nuisance_parameters
+from .sampling import nominal_nuisance_parameters

--- a/madminer/analysis/dataanalyzer.py
+++ b/madminer/analysis/dataanalyzer.py
@@ -1,9 +1,11 @@
 import logging
+
 import numpy as np
 
 from madminer.utils.interfaces.hdf5 import load_events
 from madminer.utils.interfaces.hdf5 import load_madminer_settings
-from madminer.utils.morphing import PhysicsMorpher, NuisanceMorpher
+from madminer.utils.morphing import PhysicsMorpher
+from madminer.utils.morphing import NuisanceMorpher
 from madminer.utils.various import mdot
 
 logger = logging.getLogger(__name__)

--- a/madminer/core/madminer.py
+++ b/madminer/core/madminer.py
@@ -16,9 +16,15 @@ from madminer.models import SystematicType
 from madminer.utils.morphing import PhysicsMorpher
 from madminer.utils.interfaces.hdf5 import load_madminer_settings
 from madminer.utils.interfaces.hdf5 import save_madminer_settings
-from madminer.utils.interfaces.mg_cards import export_param_card, export_reweight_card, export_run_card
-from madminer.utils.interfaces.mg import generate_mg_process, setup_mg_with_scripts, run_mg, create_master_script
-from madminer.utils.interfaces.mg import setup_mg_reweighting_with_scripts, run_mg_reweighting
+from madminer.utils.interfaces.mg_cards import export_param_card
+from madminer.utils.interfaces.mg_cards import export_reweight_card
+from madminer.utils.interfaces.mg_cards import export_run_card
+from madminer.utils.interfaces.mg import generate_mg_process
+from madminer.utils.interfaces.mg import setup_mg_with_scripts
+from madminer.utils.interfaces.mg import run_mg
+from madminer.utils.interfaces.mg import create_master_script
+from madminer.utils.interfaces.mg import setup_mg_reweighting_with_scripts
+from madminer.utils.interfaces.mg import run_mg_reweighting
 from madminer.utils.various import copy_file
 
 logger = logging.getLogger(__name__)

--- a/madminer/delphes/delphes_reader.py
+++ b/madminer/delphes/delphes_reader.py
@@ -1,8 +1,9 @@
 import logging
-import numpy as np
 
 from collections import OrderedDict
 from pathlib import Path
+
+import numpy as np
 
 from madminer.models import Cut
 from madminer.models import Observable
@@ -13,7 +14,8 @@ from madminer.utils.interfaces.hdf5 import load_madminer_settings
 from madminer.utils.interfaces.hdf5 import save_events
 from madminer.utils.interfaces.hdf5 import save_nuisance_setup
 from madminer.utils.interfaces.hepmc import extract_weight_order
-from madminer.utils.interfaces.lhe import parse_lhe_file, extract_nuisance_parameters_from_lhe_file
+from madminer.utils.interfaces.lhe import parse_lhe_file
+from madminer.utils.interfaces.lhe import extract_nuisance_parameters_from_lhe_file
 from madminer.sampling import combine_and_shuffle
 
 logger = logging.getLogger(__name__)

--- a/madminer/fisherinformation/__init__.py
+++ b/madminer/fisherinformation/__init__.py
@@ -1,3 +1,4 @@
 from .information import FisherInformation
-from .manipulate import profile_information, project_information
+from .manipulate import profile_information
+from .manipulate import project_information
 from .geometry import InformationGeometry

--- a/madminer/fisherinformation/geometry.py
+++ b/madminer/fisherinformation/geometry.py
@@ -1,8 +1,11 @@
 import logging
-import numpy as np
 import random
 
-from scipy.interpolate import griddata, LinearNDInterpolator, CloughTocher2DInterpolator
+import numpy as np
+
+from scipy.interpolate import griddata
+from scipy.interpolate import LinearNDInterpolator
+from scipy.interpolate import CloughTocher2DInterpolator
 from scipy.stats import chi2
 
 from ..utils.various import load_and_check

--- a/madminer/fisherinformation/information.py
+++ b/madminer/fisherinformation/information.py
@@ -1,12 +1,19 @@
 import logging
-import numpy as np
 
 from pathlib import Path
 
+import numpy as np
+
 from madminer.analysis import DataAnalyzer
-from madminer.utils.various import math_commands, weighted_quantile, sanitize_array, mdot
+from madminer.utils.various import math_commands
+from madminer.utils.various import weighted_quantile
+from madminer.utils.various import sanitize_array
+from madminer.utils.various import mdot
 from madminer.utils.various import less_logging
-from madminer.ml import ParameterizedRatioEstimator, ScoreEstimator, Ensemble, load_estimator
+from madminer.ml import ParameterizedRatioEstimator
+from madminer.ml import ScoreEstimator
+from madminer.ml import Ensemble
+from madminer.ml import load_estimator
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/lhe/lhe_reader.py
+++ b/madminer/lhe/lhe_reader.py
@@ -1,6 +1,8 @@
 import logging
-import numpy as np
+
 from collections import OrderedDict
+
+import numpy as np
 
 from madminer.models import Cut
 from madminer.models import Efficiency
@@ -9,11 +11,9 @@ from madminer.models import NuisanceParameter
 from madminer.utils.interfaces.hdf5 import load_madminer_settings
 from madminer.utils.interfaces.hdf5 import save_events
 from madminer.utils.interfaces.hdf5 import save_nuisance_setup
-from madminer.utils.interfaces.lhe import (
-    parse_lhe_file,
-    extract_nuisance_parameters_from_lhe_file,
-    get_elementary_pdg_ids,
-)
+from madminer.utils.interfaces.lhe import parse_lhe_file
+from madminer.utils.interfaces.lhe import extract_nuisance_parameters_from_lhe_file
+from madminer.utils.interfaces.lhe import get_elementary_pdg_ids
 from madminer.sampling import combine_and_shuffle
 
 logger = logging.getLogger(__name__)

--- a/madminer/likelihood/__init__.py
+++ b/madminer/likelihood/__init__.py
@@ -1,3 +1,5 @@
 from .histo import HistoLikelihood
 from .neural import NeuralLikelihood
-from .manipulate import profile_log_likelihood, project_log_likelihood, fix_params
+from .manipulate import profile_log_likelihood
+from .manipulate import project_log_likelihood
+from .manipulate import fix_params

--- a/madminer/likelihood/base.py
+++ b/madminer/likelihood/base.py
@@ -1,8 +1,11 @@
 import logging
-import numpy as np
 
 from abc import abstractmethod
-from scipy.stats import poisson, norm
+
+import numpy as np
+
+from scipy.stats import poisson
+from scipy.stats import norm
 
 from ..analysis import DataAnalyzer
 from ..utils.various import mdot

--- a/madminer/likelihood/histo.py
+++ b/madminer/likelihood/histo.py
@@ -1,12 +1,18 @@
 import logging
-import numpy as np
+
 from itertools import product
+
+import numpy as np
 
 from .base import BaseLikelihood
 from .. import sampling
-from ..ml import ScoreEstimator, Ensemble, load_estimator
+from ..ml import ScoreEstimator
+from ..ml import Ensemble
+from ..ml import load_estimator
 from ..utils.histo import Histo
-from ..utils.various import mdot, less_logging, math_commands
+from ..utils.various import mdot
+from ..utils.various import less_logging
+from ..utils.various import math_commands
 from ..sampling import SampleAugmenter
 
 logger = logging.getLogger(__name__)

--- a/madminer/likelihood/manipulate.py
+++ b/madminer/likelihood/manipulate.py
@@ -1,6 +1,8 @@
 import logging
-import numpy as np
 import time
+
+import numpy as np
+
 from scipy.stats import chi2
 from scipy.optimize import minimize
 

--- a/madminer/likelihood/neural.py
+++ b/madminer/likelihood/neural.py
@@ -1,8 +1,12 @@
 import logging
+
 import numpy as np
 
 from .base import BaseLikelihood
-from ..ml import ParameterizedRatioEstimator, Ensemble, LikelihoodEstimator, load_estimator
+from ..ml import ParameterizedRatioEstimator
+from ..ml import Ensemble
+from ..ml import LikelihoodEstimator
+from ..ml import load_estimator
 from ..utils.various import less_logging
 
 logger = logging.getLogger(__name__)

--- a/madminer/limits/asymptotic_limits.py
+++ b/madminer/limits/asymptotic_limits.py
@@ -1,12 +1,20 @@
 import logging
+
 import numpy as np
-from scipy.stats import chi2, poisson
+
+from scipy.stats import chi2
+from scipy.stats import poisson
 
 from madminer import sampling
 from madminer.analysis import DataAnalyzer
-from madminer.ml import ParameterizedRatioEstimator, Ensemble, ScoreEstimator, LikelihoodEstimator, load_estimator
+from madminer.ml import ParameterizedRatioEstimator
+from madminer.ml import Ensemble
+from madminer.ml import ScoreEstimator
+from madminer.ml import LikelihoodEstimator
+from madminer.ml import load_estimator
 from madminer.utils.histo import Histo
-from madminer.utils.various import mdot, less_logging
+from madminer.utils.various import mdot
+from madminer.utils.various import less_logging
 from madminer.sampling import SampleAugmenter
 
 logger = logging.getLogger(__name__)

--- a/madminer/ml/__init__.py
+++ b/madminer/ml/__init__.py
@@ -2,6 +2,7 @@ from .double_parameterized_ratio import DoubleParameterizedRatioEstimator
 from .ensemble import Ensemble
 from .likelihood import LikelihoodEstimator
 from .lookup import load_estimator
-from .morphing_aware import MorphingAwareRatioEstimator, QuadraticMorphingAwareRatioEstimator
+from .morphing_aware import MorphingAwareRatioEstimator
+from .morphing_aware import QuadraticMorphingAwareRatioEstimator
 from .parameterized_ratio import ParameterizedRatioEstimator
 from .score import ScoreEstimator

--- a/madminer/ml/base.py
+++ b/madminer/ml/base.py
@@ -1,14 +1,14 @@
 import json
 import logging
-import numpy as np
-import torch
 
 from abc import ABC
 from abc import abstractmethod
 from pathlib import Path
 
-from ..utils.various import load_and_check
+import numpy as np
+import torch
 
+from ..utils.various import load_and_check
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/ml/double_parameterized_ratio.py
+++ b/madminer/ml/double_parameterized_ratio.py
@@ -1,15 +1,19 @@
 import logging
-import numpy as np
 
 from collections import OrderedDict
 
-from .base import ConditionalEstimator, TheresAGoodReasonThisDoesntWork
+import numpy as np
+
+from .base import ConditionalEstimator
+from .base import TheresAGoodReasonThisDoesntWork
 from ..utils.ml.eval import evaluate_ratio_model
 from ..utils.ml.models.ratio import DenseDoublyParameterizedRatioModel
 from ..utils.ml.trainer import DoubleParameterizedRatioTrainer
-from ..utils.ml.utils import get_optimizer, get_loss
-from ..utils.various import load_and_check, shuffle, restrict_samplesize
-
+from ..utils.ml.utils import get_optimizer
+from ..utils.ml.utils import get_loss
+from ..utils.various import load_and_check
+from ..utils.various import shuffle
+from ..utils.various import restrict_samplesize
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/ml/ensemble.py
+++ b/madminer/ml/ensemble.py
@@ -1,16 +1,17 @@
 import json
 import logging
+
+from pathlib import Path
+
 import numpy as np
 
 from madminer.utils.various import load_and_check
-from pathlib import Path
 
 from .base import Estimator
 from .double_parameterized_ratio import DoubleParameterizedRatioEstimator
 from .likelihood import LikelihoodEstimator
 from .parameterized_ratio import ParameterizedRatioEstimator
 from .score import ScoreEstimator
-
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/ml/likelihood.py
+++ b/madminer/ml/likelihood.py
@@ -1,16 +1,19 @@
 import logging
-import numpy as np
 
 from collections import OrderedDict
+
+import numpy as np
 
 from .base import ConditionalEstimator
 from ..utils.ml.eval import evaluate_flow_model
 from ..utils.ml.models.maf import ConditionalMaskedAutoregressiveFlow
 from ..utils.ml.models.maf_mog import ConditionalMixtureMaskedAutoregressiveFlow
 from ..utils.ml.trainer import FlowTrainer
-from ..utils.ml.utils import get_optimizer, get_loss
-from ..utils.various import load_and_check, shuffle, restrict_samplesize
-
+from ..utils.ml.utils import get_optimizer
+from ..utils.ml.utils import get_loss
+from ..utils.various import load_and_check
+from ..utils.various import shuffle
+from ..utils.various import restrict_samplesize
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/ml/morphing_aware.py
+++ b/madminer/ml/morphing_aware.py
@@ -1,11 +1,12 @@
 import logging
+
 import numpy as np
 
 from .parameterized_ratio import ParameterizedRatioEstimator
 from ..utils.interfaces.hdf5 import load_madminer_settings
-from ..utils.ml.models.ratio import DenseMorphingAwareRatioModel, DenseQuadraticMorphingAwareRatioModel
+from ..utils.ml.models.ratio import DenseMorphingAwareRatioModel
+from ..utils.ml.models.ratio import DenseQuadraticMorphingAwareRatioModel
 from ..utils.morphing import PhysicsMorpher
-
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/ml/parameterized_ratio.py
+++ b/madminer/ml/parameterized_ratio.py
@@ -1,16 +1,20 @@
 import logging
-import numpy as np
-import torch
 
 from collections import OrderedDict
 
-from .base import ConditionalEstimator, TheresAGoodReasonThisDoesntWork
+import numpy as np
+import torch
+
+from .base import ConditionalEstimator
+from .base import TheresAGoodReasonThisDoesntWork
 from ..utils.ml.eval import evaluate_ratio_model
 from ..utils.ml.models.ratio import DenseSingleParameterizedRatioModel
 from ..utils.ml.trainer import SingleParameterizedRatioTrainer
-from ..utils.ml.utils import get_optimizer, get_loss
-from ..utils.various import load_and_check, shuffle, restrict_samplesize
-
+from ..utils.ml.utils import get_optimizer
+from ..utils.ml.utils import get_loss
+from ..utils.various import load_and_check
+from ..utils.various import shuffle
+from ..utils.various import restrict_samplesize
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/ml/score.py
+++ b/madminer/ml/score.py
@@ -1,14 +1,20 @@
 import logging
-import numpy as np
+
 from collections import OrderedDict
 
-from .base import Estimator, TheresAGoodReasonThisDoesntWork
+import numpy as np
+
+from .base import Estimator
+from .base import TheresAGoodReasonThisDoesntWork
 from ..utils.ml.eval import evaluate_local_score_model
 from ..utils.ml.models.score import DenseLocalScoreModel
 from ..utils.ml.trainer import LocalScoreTrainer
-from ..utils.ml.utils import get_optimizer, get_loss
-from ..utils.various import load_and_check, shuffle, restrict_samplesize, separate_information_blocks
-
+from ..utils.ml.utils import get_optimizer
+from ..utils.ml.utils import get_loss
+from ..utils.various import load_and_check
+from ..utils.various import shuffle
+from ..utils.various import restrict_samplesize
+from ..utils.various import separate_information_blocks
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/plotting/__init__.py
+++ b/madminer/plotting/__init__.py
@@ -1,14 +1,16 @@
-from .distributions import plot_distributions, plot_histograms
-from .morphing import (
-    plot_1d_morphing_basis,
-    plot_2d_morphing_basis,
-    plot_nd_morphing_basis_scatter,
-    plot_nd_morphing_basis_slices,
-)
-from .fisherinformation import (
-    plot_fisherinfo_barplot,
-    plot_fisher_information_contours_2d,
-    plot_distribution_of_information,
-)
+from .distributions import plot_distributions
+from .distributions import plot_histograms
+
+from .morphing import plot_1d_morphing_basis
+from .morphing import plot_2d_morphing_basis
+from .morphing import plot_nd_morphing_basis_scatter
+from .morphing import plot_nd_morphing_basis_slices
+
+from .fisherinformation import plot_fisherinfo_barplot
+from .fisherinformation import plot_fisher_information_contours_2d
+from .fisherinformation import plot_distribution_of_information
+
 from .limits import plot_pvalue_limits
-from .uncertainties import plot_systematics, plot_uncertainty
+
+from .uncertainties import plot_systematics
+from .uncertainties import plot_uncertainty

--- a/madminer/plotting/distributions.py
+++ b/madminer/plotting/distributions.py
@@ -1,11 +1,16 @@
 import logging
+
 import matplotlib
 import numpy as np
+
 from matplotlib import pyplot as plt
 
 from ..sampling import SampleAugmenter
 from ..utils.morphing import NuisanceMorpher
-from ..utils.various import shuffle, sanitize_array, mdot, weighted_quantile
+from ..utils.various import shuffle
+from ..utils.various import sanitize_array
+from ..utils.various import mdot
+from ..utils.various import weighted_quantile
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/plotting/uncertainties.py
+++ b/madminer/plotting/uncertainties.py
@@ -1,10 +1,15 @@
 import logging
+
 import numpy as np
-from matplotlib import pyplot as plt, gridspec
+
+from matplotlib import pyplot as plt
+from matplotlib import gridspec
 
 from ..sampling import SampleAugmenter
 from ..utils.morphing import NuisanceMorpher
-from ..utils.various import mdot, shuffle, sanitize_array
+from ..utils.various import mdot
+from ..utils.various import shuffle
+from ..utils.various import sanitize_array
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/sampling/__init__.py
+++ b/madminer/sampling/__init__.py
@@ -1,11 +1,11 @@
 from .sampleaugmenter import SampleAugmenter
-from .parameters import (
-    benchmark,
-    benchmarks,
-    morphing_point,
-    morphing_points,
-    random_morphing_points,
-    nominal_nuisance_parameters,
-    iid_nuisance_parameters,
-)
+
+from .parameters import benchmark
+from .parameters import benchmarks
+from .parameters import morphing_point
+from .parameters import morphing_points
+from .parameters import random_morphing_points
+from .parameters import nominal_nuisance_parameters
+from .parameters import iid_nuisance_parameters
+
 from .combine import combine_and_shuffle

--- a/madminer/sampling/combine.py
+++ b/madminer/sampling/combine.py
@@ -1,10 +1,11 @@
 import logging
-import numpy as np
 import shutil
 
 from contextlib import suppress
 from typing import List
 from typing import Union
+
+import numpy as np
 
 from ..utils.interfaces.hdf5 import load_events
 from ..utils.interfaces.hdf5 import load_madminer_settings

--- a/madminer/sampling/sampleaugmenter.py
+++ b/madminer/sampling/sampleaugmenter.py
@@ -1,10 +1,11 @@
 import time
 import logging
-import numpy as np
 import multiprocessing
 
 from functools import partial
 from pathlib import Path
+
+import numpy as np
 
 from ..analysis import DataAnalyzer
 from ..utils.various import shuffle

--- a/madminer/utils/histo.py
+++ b/madminer/utils/histo.py
@@ -1,5 +1,6 @@
 import logging
 import numpy as np
+
 from madminer.utils.various import weighted_quantile
 
 logger = logging.getLogger(__name__)

--- a/madminer/utils/interfaces/delphes.py
+++ b/madminer/utils/interfaces/delphes.py
@@ -2,7 +2,8 @@ import logging
 
 from pathlib import Path
 
-from madminer.utils.various import call_command, unzip_file
+from madminer.utils.various import call_command
+from madminer.utils.various import unzip_file
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -1,12 +1,13 @@
 import logging
-import numpy as np
 import os
-import uproot3
 
 from collections import OrderedDict
 from typing import Callable
 from typing import Dict
 from typing import List
+
+import numpy as np
+import uproot3
 
 from particle import Particle
 from madminer.models import Cut

--- a/madminer/utils/interfaces/hdf5.py
+++ b/madminer/utils/interfaces/hdf5.py
@@ -1,6 +1,4 @@
-import h5py
 import logging
-import numpy as np
 import shutil
 
 from collections import OrderedDict
@@ -12,6 +10,9 @@ from typing import List
 from typing import Tuple
 from typing import Union
 
+import h5py
+import numpy as np
+
 from madminer.models import AnalysisParameter
 from madminer.models import NuisanceParameter
 from madminer.models import Benchmark
@@ -21,7 +22,6 @@ from madminer.models import Systematic
 from madminer.models import SystematicScale
 from madminer.models import SystematicType
 from madminer.models import SystematicValue
-
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -1,5 +1,4 @@
 import logging
-import numpy as np
 import xml.etree.ElementTree as ET
 
 from collections import OrderedDict
@@ -7,6 +6,8 @@ from pathlib import Path
 from typing import Callable
 from typing import Dict
 from typing import List
+
+import numpy as np
 
 from particle import Particle
 from madminer.models import Cut
@@ -16,7 +17,9 @@ from madminer.models import Systematic
 from madminer.models import SystematicScale
 from madminer.models import SystematicType
 from madminer.utils.particle import MadMinerParticle
-from madminer.utils.various import unzip_file, approx_equal, math_commands
+from madminer.utils.various import unzip_file
+from madminer.utils.various import approx_equal
+from madminer.utils.various import math_commands
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -3,7 +3,8 @@ import shutil
 
 from pathlib import Path
 
-from madminer.utils.various import call_command, make_file_executable
+from madminer.utils.various import call_command
+from madminer.utils.various import make_file_executable
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/eval.py
+++ b/madminer/utils/ml/eval.py
@@ -1,12 +1,11 @@
 import logging
+
 import numpy as np
 import torch
 from torch import tensor
 
-from madminer.utils.ml.models.ratio import (
-    DenseSingleParameterizedRatioModel,
-    DenseDoublyParameterizedRatioModel,
-)
+from madminer.utils.ml.models.ratio import DenseSingleParameterizedRatioModel
+from madminer.utils.ml.models.ratio import DenseDoublyParameterizedRatioModel
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/losses.py
+++ b/madminer/utils/ml/losses.py
@@ -1,7 +1,9 @@
 import logging
+
 import numpy as np
 import torch
-from torch.nn import BCELoss, MSELoss
+from torch.nn import BCELoss
+from torch.nn import MSELoss
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/models/base.py
+++ b/madminer/utils/ml/models/base.py
@@ -1,8 +1,9 @@
+from abc import abstractmethod
+
 import numpy as np
 import torch
 import torch.nn as nn
 
-from abc import abstractmethod
 from torch.autograd import grad
 
 

--- a/madminer/utils/ml/models/batch_norm.py
+++ b/madminer/utils/ml/models/batch_norm.py
@@ -1,9 +1,10 @@
 import logging
+
 import numpy.random as rng
 import torch
 
-from madminer.utils.ml.models.base import BaseFlow
 from torch import tensor
+from madminer.utils.ml.models.base import BaseFlow
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/models/made.py
+++ b/madminer/utils/ml/models/made.py
@@ -1,14 +1,19 @@
 import logging
+
 import numpy as np
 import numpy.random as rng
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from madminer.utils.ml.models.base import BaseFlow, BaseConditionalFlow
-from madminer.utils.ml.models.masks import create_degrees, create_masks, create_weights, create_weights_conditional
-from madminer.utils.ml.utils import get_activation_function
 from torch import tensor
+from madminer.utils.ml.models.base import BaseFlow
+from madminer.utils.ml.models.base import BaseConditionalFlow
+from madminer.utils.ml.models.masks import create_degrees
+from madminer.utils.ml.models.masks import create_masks
+from madminer.utils.ml.models.masks import create_weights
+from madminer.utils.ml.models.masks import create_weights_conditional
+from madminer.utils.ml.utils import get_activation_function
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/models/made_mog.py
+++ b/madminer/utils/ml/models/made_mog.py
@@ -1,13 +1,16 @@
 import logging
+
 import numpy as np
 import numpy.random as rng
 import torch
 import torch.nn.functional as F
 
-from madminer.utils.ml.models.base import BaseConditionalFlow
-from madminer.utils.ml.models.masks import create_degrees, create_masks, create_weights_conditional
-from madminer.utils.ml.utils import get_activation_function
 from torch import tensor
+from madminer.utils.ml.models.base import BaseConditionalFlow
+from madminer.utils.ml.models.masks import create_degrees
+from madminer.utils.ml.models.masks import create_masks
+from madminer.utils.ml.models.masks import create_weights_conditional
+from madminer.utils.ml.utils import get_activation_function
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/models/maf.py
+++ b/madminer/utils/ml/models/maf.py
@@ -1,10 +1,13 @@
 import logging
+
 import numpy.random as rng
 import torch.nn as nn
 
 from torch import tensor
-from madminer.utils.ml.models.base import BaseFlow, BaseConditionalFlow
-from madminer.utils.ml.models.made import GaussianMADE, ConditionalGaussianMADE
+from madminer.utils.ml.models.base import BaseFlow
+from madminer.utils.ml.models.base import BaseConditionalFlow
+from madminer.utils.ml.models.made import GaussianMADE
+from madminer.utils.ml.models.made import ConditionalGaussianMADE
 from madminer.utils.ml.models.batch_norm import BatchNorm
 
 logger = logging.getLogger(__name__)

--- a/madminer/utils/ml/models/ratio.py
+++ b/madminer/utils/ml/models/ratio.py
@@ -1,10 +1,11 @@
 import logging
+
 import numpy as np
 import torch
 import torch.nn as nn
 
-from madminer.utils.ml.utils import get_activation_function, check_for_nan, check_for_nonpos, NanException
 from torch.autograd import grad
+from madminer.utils.ml.utils import get_activation_function
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/models/score.py
+++ b/madminer/utils/ml/models/score.py
@@ -1,9 +1,10 @@
 import logging
+
 import torch
 import torch.nn as nn
 
-from madminer.utils.ml.utils import get_activation_function
 from torch.autograd import grad
+from madminer.utils.ml.utils import get_activation_function
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/ml/trainer.py
+++ b/madminer/utils/ml/trainer.py
@@ -1,19 +1,19 @@
 import logging
-import numpy as np
 import time
+
+from collections import OrderedDict
+
+import numpy as np
 import torch
 import torch.optim as optim
 
-from collections import OrderedDict
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader
 from torch.utils.data.sampler import SubsetRandomSampler
 
-from madminer.utils.ml.utils import (
-    EarlyStoppingException,
-    NanException,
-    NumpyDataset,
-)
+from madminer.utils.ml.utils import EarlyStoppingException
+from madminer.utils.ml.utils import NanException
+from madminer.utils.ml.utils import NumpyDataset
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/morphing.py
+++ b/madminer/utils/morphing.py
@@ -1,11 +1,12 @@
 import itertools
 import logging
-import numpy as np
-import sympy as sp
 
 from collections import OrderedDict
 from typing import Dict
 from typing import Iterable
+
+import numpy as np
+import sympy as sp
 
 from madminer.models import Benchmark
 from madminer.models import AnalysisParameter

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -1,13 +1,15 @@
 import logging
 import gzip
 import math
-import numpy as np
 import os
 import shutil
 import stat
 
 from contextlib import contextmanager
-from subprocess import Popen, PIPE
+from subprocess import Popen
+from subprocess import PIPE
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ exclude = '''
   | mg_processes
 )
 '''
+
+[tool.isort]
+force_single_line = true
+ignore_whitespace = true
+only_sections = true
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ docs =
     sphinx_rtd_theme
 lint =
     black[jupyter]>=22.12.0
+    isort>=5.11.3
 test =
     pytest
 examples =

--- a/tests/test_nuisance.py
+++ b/tests/test_nuisance.py
@@ -1,9 +1,14 @@
 import os
-import numpy as np
+
 from collections import OrderedDict
 
+import numpy as np
+
 from madminer.models import NuisanceParameter
-from madminer import MadMiner, LHEReader, FisherInformation, profile_information
+from madminer import MadMiner
+from madminer import LHEReader
+from madminer import FisherInformation
+from madminer import profile_information
 
 
 def theta_limit_madminer(xsec=0.001, lumi=1000000.0, effect_phys=0.1, effect_sys=0.1):

--- a/tests/test_ratio_estimation.py
+++ b/tests/test_ratio_estimation.py
@@ -1,10 +1,10 @@
 import os
-import numpy as np
 import logging
 
-from madminer import ParameterizedRatioEstimator
+import numpy as np
 from scipy.stats import norm
 
+from madminer import ParameterizedRatioEstimator
 
 # MadMiner output
 logging.basicConfig(

--- a/tests/utils/interfaces/hdf5.py
+++ b/tests/utils/interfaces/hdf5.py
@@ -4,11 +4,9 @@ from tempfile import mkstemp
 import pytest
 
 from madminer.models import Observable
-from madminer.utils.interfaces.hdf5 import (
-    EMPTY_EXPR,
-    _load_observables,
-    _save_observables,
-)
+from madminer.utils.interfaces.hdf5 import EMPTY_EXPR
+from madminer.utils.interfaces.hdf5 import _load_observables
+from madminer.utils.interfaces.hdf5 import _save_observables
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This PR adds isort latest version (`5.11.3`) to the [lint dependencies](https://github.com/madminer-tool/madminer/blob/92440bfed3e30d1539464a8127898c060ddd3694/setup.cfg#L50-L51), and lints the whole package accordingly.

---

Finally, I included all relevant folders (`madminer` and `tests`) into the [CI pipeline](https://github.com/madminer-tool/madminer/blob/master/.github/workflows/ci.yml) `lint` step in order to preserve _isort compliance_ in the future.