### PR TITLE
Remove unnecessary MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-### NOTE:
-###
-### This file is required when creating a "source distribution":
-###
-### Reference: https://packaging.python.org/guides/using-manifest-in/
-### Command: $ python -m build --sdist ...
-
-include README.md
-include VERSION


### PR DESCRIPTION
This PR removes the unnecessary `MANIFEST.in` file from the project.

Upon preliminar testing, setuptools has been automatically picking up `setup.cfg` metadata required files, when building _source distributions_, for a few versions now (therefore, issue https://github.com/pypa/setuptools/issues/2821 should have been closed some time ago).

Given that we are only leveraging `MANIFEST.in` to include metadata required file, we can get rid of it.