### PR TITLE
feat: switch from uproot3 to uproot

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,5 @@ dependencies:
 - pip
 - pip:
   - particle>=0.16.0
-  - uproot3>=3.14.1
+  - uproot>=4.0.0
   - vector>=0.8.4

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -7,7 +7,7 @@ from typing import Dict
 from typing import List
 
 import numpy as np
-import uproot3
+import uproot
 
 from particle import Particle
 from madminer.models import Cut
@@ -44,10 +44,8 @@ def parse_delphes_root_file(
         logger.debug("Extracting weights %s", weight_labels)
 
     # Delphes ROOT file
-    root_file = uproot3.open(delphes_sample_file)
-
-    # Delphes tree
-    tree = root_file["Delphes"]
+    with uproot.open(delphes_sample_file) as root_file:
+        tree = root_file["Delphes"]
 
     # Weights
     weights = None

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -17,6 +17,10 @@ from madminer.utils.various import math_commands
 
 logger = logging.getLogger(__name__)
 
+# Sets uproot methods return types to be Numpy based
+# Ref: https://uproot.readthedocs.io/en/latest/uproot3-to-4.html#reading-arrays
+uproot.default_library = "np"
+
 
 def parse_delphes_root_file(
     delphes_sample_file,

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     particle>=0.16.0
     scipy>=1.0.0
     torch>=1.0.0
-    uproot3>=3.14.1
+    uproot>=4.0.0
     vector>=0.8.4
     sympy>=0.7.4
 


### PR DESCRIPTION
This PR bumps the uproot dependency from versions `>=3.14.1` to versions `>=4.0.0`, overseeding https://github.com/madminer-tool/madminer/pull/511.

It also states Numpy as the _default-library_. According to the [uproot 3 -> 4 migration docs](https://uproot.readthedocs.io/en/latest/uproot3-to-4.html):

> **Uproot 3 chooses between NumPy and Awkward Array** based on the type of the data. Since NumPy arrays and Awkward Arrays have different methods and properties, it’s safer to write scripts with a deterministic output type.
>
> Note: Awkward Array is not one of Uproot 4’s formal requirements. If you don’t have awkward installed, array() and arrays() **will raise errors explaining how to install Awkward Array or switch to library="np"**