### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,10 @@ jobs:
         python-version: "3.10"
     - name: "Install Python dependencies"
       run: |
-        pip install --no-cache-dir --upgrade pip setuptools wheel
-        pip install --no-cache-dir --quiet ".[lint]"
-        pip list
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --quiet ".[lint]"
+        uv pip list --system
     - name: "Check format"
       run: |
         make check
@@ -58,9 +59,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: "Install Python dependencies"
       run: |
-        pip install --no-cache-dir --upgrade pip setuptools wheel
-        pip install --no-cache-dir --quiet ".[test]"
-        pip list
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --quiet ".[test]"
+        uv pip list --system
     - name: "Test with pytest"
       run: |
         make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         python -m pip install --upgrade uv
         uv pip install --system --upgrade pip setuptools wheel
-        uv pip install --system --quiet ".[lint]"
+        uv pip install --system ".[lint]"
         uv pip list --system
     - name: "Check format"
       run: |
@@ -61,7 +61,7 @@ jobs:
       run: |
         python -m pip install --upgrade uv
         uv pip install --system --upgrade pip setuptools wheel
-        uv pip install --system --quiet ".[test]"
+        uv pip install --system ".[test]"
         uv pip list --system
     - name: "Test with pytest"
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade uv
         uv pip install --system --upgrade pip setuptools wheel
-        uv pip install --system --quiet ".[docs]"
+        uv pip install --system ".[docs]"
         uv pip list --system
     - name: "Build documentation"
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,9 +35,10 @@ jobs:
         python-version: "3.10"
     - name: "Install Python dependencies"
       run: |
-        pip install --no-cache-dir --upgrade pip setuptools wheel
-        pip install --no-cache-dir --quiet ".[docs]"
-        pip list
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --quiet ".[docs]"
+        uv pip list --system
     - name: "Build documentation"
       run: |
         make docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,15 +25,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - name: "Install Python dependencies"
-      run: |
-        pip install --no-cache-dir --upgrade pip setuptools wheel
-        pip install --no-cache-dir --upgrade build
-        pip install --no-cache-dir --quiet .
-        pip list
     - name: "Build Python package"
       run: |
-        make build
+        pipx run build --installer uv
     - name: "Publish Python package"
       uses: pypa/gh-action-pypi-publish@v1.8.14
       with:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TESTS_FOLDER  = "tests"
 .PHONY: build
 build:
 	@echo "Building package"
-	@python -m build --sdist --wheel --outdir dist .
+	@python -m build --installer uv .
 
 
 .PHONY: check


### PR DESCRIPTION
* Use 'uv pip' for all calls to 'pip install' in CI workflows.
   - c.f. https://github.com/astral-sh/uv/
* Use 'pipx run' over a Make command.

```
* Use 'uv pip' for all calls to 'pip install' in CI workflows.
   - c.f. https://github.com/astral-sh/uv/
* Use 'pipx run' over a Make command.
```