### PR TITLE
ci: Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Set up GitHub Actions"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Set up Python"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: "Install Python dependencies"
       run: |
         python -m pip install --upgrade uv
@@ -52,9 +52,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     steps:
     - name: "Set up GitHub Actions"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Set up Python ${{ matrix.python-version }}"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install Python dependencies"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Set up GitHub Actions"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Set up Python"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: "Install Python dependencies"
       run: |
         python -m pip install --upgrade uv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Set up GitHub Actions"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: "Set up Python"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: "Build Python package"
       run: |
         pipx run build --installer uv


### PR DESCRIPTION
* Update actions/checkout to v4.
* Update actions/setup-python to v5.
* Use python '3.x' for non tests.