### PR TITLE
Fix syntax warnings

### DIFF
--- a/madminer/fisherinformation/geometry.py
+++ b/madminer/fisherinformation/geometry.py
@@ -161,7 +161,7 @@ class InformationGeometry:
             return np.linalg.inv(self._information(theta))
 
     def _information_derivative(self, theta):
-        """
+        r"""
         Low level function that calculates the derivative of Fisher Information
         `\partial_k I_{ij}` at the theory parameter `theta`.
 
@@ -184,7 +184,7 @@ class InformationGeometry:
         )
 
     def _christoffel(self, theta):
-        """
+        r"""
         Low level function that calculates the Christoffel symbol (2nd kind) Gamma^i_jk at
         the theory parameter `theta`.  Here Gamma^i_jk=0.5*I^{im}(\partial_k I_{mj}
         + \partial_j I_{mk} - \partial_m I_{jk})
@@ -346,7 +346,7 @@ class InformationGeometry:
             stepsize = min([(limit[1] - limit[0]) / 20.0 for limit in grid_ranges])
         if ntrajectories is None:
             ntrajectories = 20 * self.dimension
-        if self.dimension is not 2:
+        if self.dimension != 2:
             continous_sampling = False
 
         limits = (1.0 + 2.0 * stepsize) * np.array(grid_ranges)

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -265,7 +265,7 @@ def setup_mg_with_scripts(
         )
 
     # Replace environment variable in proc card
-    replacement_command = """sed -e 's@\$mgprocdir@'"$mgprocdir"'@' {}/{} > {}/{}""".format(
+    replacement_command = r"""sed -e 's@\$mgprocdir@'"$mgprocdir"'@' {}/{} > {}/{}""".format(
         mg_process_directory_placeholder,
         proc_card_filename_from_mgprocdir,
         mg_process_directory_placeholder,


### PR DESCRIPTION
With Python 3.12 (w/o `.pyc` cache files in `__pycache__`), by importing `madminer`,
```python
import madminer
```
I got the following warnings:
```
/home/tueda/work/madminer/madminer/utils/interfaces/mg.py:268: SyntaxWarning: invalid escape sequence '\$'
  replacement_command = """sed -e 's@\$mgprocdir@'"$mgprocdir"'@' {}/{} > {}/{}""".format(
/home/tueda/work/madminer/madminer/fisherinformation/geometry.py:164: SyntaxWarning: invalid escape sequence '\p'
  """
/home/tueda/work/madminer/madminer/fisherinformation/geometry.py:187: SyntaxWarning: invalid escape sequence '\p'
  """
/home/tueda/work/madminer/madminer/fisherinformation/geometry.py:349: SyntaxWarning: "is not" with 'int' literal. Did you mean "!="?
  if self.dimension is not 2:
```
This patch resolves these warnings.


The last warning `SyntaxWarning: "is not" with 'int' literal` may need some explanation: indeed, I expect the current code to work correctly due to CPython's optimization of small integers (from `-5` to `256`),
```python
x = 2
print(x is 2)  # prints True
```
but using `is` for integer comparison in general can lead to incorrect results. For example, the following code gives a counterintuitive result:
```python
x = 257
print(x is 257)  # prints False
```